### PR TITLE
Revert "Increment version numbers"

### DIFF
--- a/LiteDB/LiteDB.csproj
+++ b/LiteDB/LiteDB.csproj
@@ -9,10 +9,10 @@
 
   <PropertyGroup>
     <PackageId>LiteDB</PackageId>
-    <Version>4.1.6</Version>
-    <AssemblyVersion>4.1.6.0</AssemblyVersion>
-    <FileVersion>4.1.6</FileVersion>
-    <VersionPrefix>4.1.6</VersionPrefix>
+    <Version>4.1.5</Version>
+    <AssemblyVersion>4.1.5.0</AssemblyVersion>
+    <FileVersion>4.1.5</FileVersion>
+    <VersionPrefix>4.1.5</VersionPrefix>
     <Authors>Maurício David</Authors>
     <Product>LiteDB</Product>
     <Description>LiteDB - A lightweight embedded .NET NoSQL document store in a single datafile</Description>


### PR DESCRIPTION
This reverts commit 3ee4862c1c52ee08f74e4f2462f3824f11109476.

The commit created version conflicts between a "pure" version of LiteDB and this fork which is not the intention. The intention is to be able to replace the pure LiteDB version with this version without API changes.